### PR TITLE
MB-57973: Validate custom date time parser layouts

### DIFF
--- a/mapping_test.go
+++ b/mapping_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestCleanse(t *testing.T) {
@@ -69,5 +70,167 @@ func TestCleanse(t *testing.T) {
 	}
 	if _, exists := m2["mm"].(map[string]interface{})["display_order"]; exists {
 		t.Errorf("m2.mm.display_order")
+	}
+}
+
+func TestLayoutValidatorRegex(t *testing.T) {
+	splitRegexTests := []struct {
+		input  string
+		output []string
+	}{
+		{
+			input:  "2014-08-03",
+			output: []string{"2014", "08", "03"},
+		},
+		{
+			input:  "2014-08-03T15:59:30",
+			output: []string{"2014", "08", "03", "15", "59", "30"},
+		},
+		{
+			input:  "2014.08-03 15/59`30",
+			output: []string{"2014", "08", "03", "15", "59", "30"},
+		},
+		{
+			input:  "2014/08/03T15:59:30Z08:00",
+			output: []string{"2014", "08", "03", "15", "59", "30", "08", "00"},
+		},
+		{
+			input:  "2014\\08|03T15=59.30.999999999+08*00",
+			output: []string{"2014", "08", "03", "15", "59", "30", "999999999", "08", "00"},
+		},
+		{
+			input:  "2006-01-02T15:04:05.999999999Z07:00",
+			output: []string{"2006", "01", "02", "15", "04", "05", "999999999", "07", "00"},
+		},
+		{
+			input: "A-B C:DTE,FZG.H<I>J;K?L!M`N~O@P#Q$R%S^U&V*W|X'Y\"A(B)C{D}E[F]G/H\\I+J=L",
+			output: []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P",
+				"Q", "R", "S", "U", "V", "W", "X", "Y", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "L"},
+		},
+	}
+	regex := layoutSplitRegex
+	for _, test := range splitRegexTests {
+		t.Run(test.input, func(t *testing.T) {
+			actualOutput := regex.Split(test.input, -1)
+			if !reflect.DeepEqual(actualOutput, test.output) {
+				t.Fatalf("expected output %v, got %v", test.output, actualOutput)
+			}
+		})
+	}
+
+	stripRegexTests := []struct {
+		input  string
+		output string
+	}{
+		{
+			input:  "3PM",
+			output: "3",
+		},
+		{
+			input:  "3.0PM",
+			output: "3",
+		},
+		{
+			input:  "3.9AM",
+			output: "3AM",
+		},
+		{
+			input:  "3.999999999pm",
+			output: "3",
+		},
+		{
+			input:  "2006-01-02T15:04:05.999999999Z07:00MST",
+			output: "2006-01-02T15:04:05Z07:00",
+		},
+		{
+			input:  "Jan _2 15:04:05.0000000+07:00MST",
+			output: "Jan _2 15:04:05+07:00",
+		},
+		{
+			input:  "15:04:05.99PM+07:00MST",
+			output: "15:04:05+07:00",
+		},
+	}
+	regex = layoutStripRegex
+	for _, test := range stripRegexTests {
+		t.Run(test.input, func(t *testing.T) {
+			actualOutput := layoutStripRegex.ReplaceAllString(test.input, "")
+			if !reflect.DeepEqual(actualOutput, test.output) {
+				t.Fatalf("expected output %v, got %v", test.output, actualOutput)
+			}
+		})
+	}
+}
+
+func TestCustomDateTimeParserLayoutValidation(t *testing.T) {
+	correctConfig := map[string]interface{}{
+		"type": "flexiblego",
+		"layouts": []interface{}{
+			// some custom layouts
+			"2006-01-02 15:04:05.0000",
+			"2006\\01\\02T03:04:05PM",
+			"2006/01/02",
+			"2006-01-02T15:04:05.999Z0700PMMST",
+			"15:04:05.0000Z07:00 Monday",
+
+			// standard layouts
+			time.Layout,
+			time.ANSIC,
+			time.UnixDate,
+			time.RubyDate,
+			time.RFC822,
+			time.RFC822Z,
+			time.RFC850,
+			time.RFC1123,
+			time.RFC1123Z,
+			time.RFC3339,
+			time.RFC3339Nano,
+			time.Kitchen,
+			time.Stamp,
+			time.StampMilli,
+			time.StampMicro,
+			time.StampNano,
+			"2006-01-02 15:04:05", //time.DateTime
+			"2006-01-02",          //time.DateOnly
+			"15:04:05",            //time.TimeOnly
+
+			// Corrected layouts to the incorrect ones below.
+			"2006-01-02 03:04:05 -0700",
+			"2006-01-02 15:04:05 -0700",
+			"3:04PM",
+			"2006-01-02 15:04:05.000 -0700 MST",
+			"January 2 2006 3:04 PM",
+			"02/Jan/06 3:04PM",
+			"Mon 02 Jan 3:04:05 PM",
+		},
+	}
+	for _, layout := range correctConfig["layouts"].([]interface{}) {
+		if !validateDateTimeParserLayout(layout.(string)) {
+			t.Fatalf("expected layout %s to be valid", layout)
+		}
+	}
+
+	incorrectConfig := map[string]interface{}{
+		"type": "flexiblego",
+		"layouts": []interface{}{
+			"2000-03-31 01:33:51 +0300",
+			"2006-01-02 15:04:51 +0300",
+			"2000-03-31 01:33:05 +0300",
+			"4:45PM",
+			"2006-01-02 15:04:05.445 -0700 MST",
+			"August 20 2001 8:55 AM",
+			"28/Jul/23 12:48PM",
+			"Tue 22 Aug 6:37:30 AM",
+		},
+	}
+	numExpectedErrors := len(incorrectConfig["layouts"].([]interface{}))
+	numActualErrors := 0
+	for _, layout := range incorrectConfig["layouts"].([]interface{}) {
+		if !validateDateTimeParserLayout(layout.(string)) {
+			numActualErrors++
+		}
+	}
+	if numActualErrors != numExpectedErrors {
+		t.Fatalf("expected %d errors, got: %d", numExpectedErrors, numActualErrors)
 	}
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,61 @@
+package mapping
+
+import "regexp"
+
+// Used to validate date time parser formats
+var validMagicNumbers = map[string]struct{}{
+	"2006":    {},
+	"06":      {}, // Year
+	"01":      {},
+	"1":       {},
+	"_1":      {},
+	"January": {},
+	"Jan":     {}, // Month
+	"02":      {},
+	"2":       {},
+	"_2":      {},
+	"__2":     {},
+	"002":     {},
+	"Monday":  {},
+	"Mon":     {}, // Day
+	"15":      {},
+	"3":       {},
+	"03":      {}, // Hour
+	"4":       {},
+	"04":      {}, // Minute
+	"5":       {},
+	"05":      {}, // Second
+	"0700":    {},
+	"070000":  {},
+	"07":      {},
+	"00":      {},
+	"":        {},
+}
+
+var layoutSplitRegex = regexp.MustCompile("[\\+\\-= :T,Z\\.<>;\\?!`~@#$%\\^&\\*|'\"\\(\\){}\\[\\]/\\\\]")
+
+var layoutStripRegex = regexp.MustCompile(`PM|pm|\.9+|\.0+|MST`)
+
+// date time layouts must be a combination of constants specified in golang time package
+// https://pkg.go.dev/time#pkg-constants
+// this validation verifies that only these constants are used in the custom layout
+// for compatibility with the golang time package
+func validateDateTimeParserLayout(layout string) bool {
+	// first we strip out commonly used constants
+	// such as "PM" which can be present in the layout
+	// right after a time component, e.g. 03:04PM;
+	// because regex split cannot separate "03:04PM" into
+	// "03:04" and "PM". We also strip out ".9+" and ".0+"
+	// which represent fractional seconds.
+	layout = layoutStripRegex.ReplaceAllString(layout, "")
+	// then we split the layout by non-constant characters
+	// which is a regex and verify that each split is a valid magic number
+	split := layoutSplitRegex.Split(layout, -1)
+	for i := range split {
+		_, found := validMagicNumbers[split[i]]
+		if !found {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Jira

[MB-57973](https://issues.couchbase.com/browse/MB-57973)

## Description
Currently user does not receive any feedback if the custom date time parser input by him is valid or not. These custom parsers must only contain magic numbers/ constants specified in https://pkg.go.dev/time#pkg-constants else it is not valid even though no error is returned buy the time package. The input validation here ensures only valid magic numbers are used.