### PR TITLE
MB-35347: Add REST endpoint to retrieve synonym sources from index mapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,5 +39,3 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 )
-
-replace github.com/blevesearch/bleve/v2 => ../bleve

--- a/go.mod
+++ b/go.mod
@@ -39,3 +39,5 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 )
+
+replace github.com/blevesearch/bleve/v2 => ../bleve

--- a/mapping.go
+++ b/mapping.go
@@ -220,6 +220,7 @@ func ListSynonymSources(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	synonymSources := make([]string, 0, len(indexMapping.SynonymSources))
 	for name := range indexMapping.SynonymSources {
 		synonymSources = append(synonymSources, name)
 	}

--- a/mapping.go
+++ b/mapping.go
@@ -41,19 +41,19 @@ func AssetFS() *assetfs.AssetFS {
 // RegisterHandlers registers mapping handlers on a router at the
 // given pathBase, such as at "/api".
 func RegisterHandlers(router *mux.Router, pathBase string) {
+	router.HandleFunc(pathBase+"/_analyze", AnalyzerText).Methods("POST")
 	router.HandleFunc(pathBase+"/_analyzerNames", ListAnalyzerNames).Methods("POST")
-	router.HandleFunc(pathBase+"/_datetimeParserNames", ListDateTimeParserNames).Methods("POST")
-	router.HandleFunc(pathBase+"/_synonymSources", ListSynonymSources).Methods("POST")
 	router.HandleFunc(pathBase+"/_charFilterNames", ListCharFilterNames).Methods("POST")
 	router.HandleFunc(pathBase+"/_charFilterTypes", ListCharFilterTypes).Methods("GET")
+	router.HandleFunc(pathBase+"/_datetimeParserNames", ListDateTimeParserNames).Methods("POST")
+	router.HandleFunc(pathBase+"/_dumpQuery", DumpQuery).Methods("POST")
+	router.HandleFunc(pathBase+"/_synonymSources", ListSynonymSources).Methods("POST")
 	router.HandleFunc(pathBase+"/_tokenizerNames", ListTokenizerNames).Methods("POST")
 	router.HandleFunc(pathBase+"/_tokenizerTypes", ListTokenizerTypes).Methods("GET")
 	router.HandleFunc(pathBase+"/_tokenFilterNames", ListTokenFilterNames).Methods("POST")
 	router.HandleFunc(pathBase+"/_tokenFilterTypes", ListTokenFilterTypes).Methods("GET")
 	router.HandleFunc(pathBase+"/_tokenMapNames", ListTokenMapNames).Methods("POST")
-	router.HandleFunc(pathBase+"/_analyze", AnalyzerText).Methods("POST")
 	router.HandleFunc(pathBase+"/_validateMapping", ValidateMapping).Methods("POST")
-	router.HandleFunc(pathBase+"/_dumpQuery", DumpQuery).Methods("POST")
 }
 
 func ListAnalyzerNames(w http.ResponseWriter, req *http.Request) {
@@ -192,47 +192,6 @@ func ListDateTimeParserNames(w http.ResponseWriter, req *http.Request) {
 		Status:                "ok",
 		DateTimeParsers:       dateTimeParserNames,
 		DateTimeLayoutFormats: dateTimeParserTypes,
-	}
-	mustEncode(w, rv)
-}
-
-func ListSynonymSources(w http.ResponseWriter, req *http.Request) {
-	indexMapping := bleve.NewIndexMapping()
-
-	// read the request body
-	requestBody, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		showError(w, req, fmt.Sprintf("error reading request body: %v", err), 400)
-		return
-	}
-
-	// interpret request body as index mapping
-	if len(requestBody) > 0 {
-		requestBody, err = CleanseJSON(requestBody)
-		if err != nil {
-			showError(w, req, fmt.Sprintf("error preparing index mapping: %v", err), 400)
-			return
-		}
-		err = json.Unmarshal(requestBody, &indexMapping)
-		if err != nil {
-			showError(w, req, fmt.Sprintf("error parsing index mapping: %v", err), 400)
-			return
-		}
-	}
-
-	synonymSources := make([]string, 0, len(indexMapping.SynonymSources))
-	for name := range indexMapping.SynonymSources {
-		synonymSources = append(synonymSources, name)
-	}
-
-	sort.Strings(synonymSources)
-
-	rv := struct {
-		Status         string   `json:"status"`
-		SynonymSources []string `json:"synonym_sources"`
-	}{
-		Status:         "ok",
-		SynonymSources: synonymSources,
 	}
 	mustEncode(w, rv)
 }
@@ -580,6 +539,47 @@ func DumpQuery(w http.ResponseWriter, req *http.Request) {
 	}{
 		Status: "ok",
 		Query:  queryJson,
+	}
+	mustEncode(w, rv)
+}
+
+func ListSynonymSources(w http.ResponseWriter, req *http.Request) {
+	indexMapping := bleve.NewIndexMapping()
+
+	// read the request body
+	requestBody, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		showError(w, req, fmt.Sprintf("error reading request body: %v", err), 400)
+		return
+	}
+
+	// interpret request body as index mapping
+	if len(requestBody) > 0 {
+		requestBody, err = CleanseJSON(requestBody)
+		if err != nil {
+			showError(w, req, fmt.Sprintf("error preparing index mapping: %v", err), 400)
+			return
+		}
+		err = json.Unmarshal(requestBody, &indexMapping)
+		if err != nil {
+			showError(w, req, fmt.Sprintf("error parsing index mapping: %v", err), 400)
+			return
+		}
+	}
+
+	synonymSources := make([]string, 0, indexMapping.SynonymCount())
+	for name := range indexMapping.CustomAnalysis.SynonymSources {
+		synonymSources = append(synonymSources, name)
+	}
+
+	sort.Strings(synonymSources)
+
+	rv := struct {
+		Status         string   `json:"status"`
+		SynonymSources []string `json:"synonym_sources"`
+	}{
+		Status:         "ok",
+		SynonymSources: synonymSources,
 	}
 	mustEncode(w, rv)
 }

--- a/mapping.go
+++ b/mapping.go
@@ -220,10 +220,7 @@ func ListSynonymSources(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	// built in char filter names
-	_, synonymSources := registry.SynonymSourceTypesAndInstances()
-	// add custom date time parser names
-	for name := range indexMapping.CustomAnalysis.SynonymSources {
+	for name := range indexMapping.SynonymSources {
 		synonymSources = append(synonymSources, name)
 	}
 


### PR DESCRIPTION
- This endpoint allows users to retrieve the names of synonym sources defined in an 
  index mapping, enhancing accessibility and configurability for synonym-related features.
